### PR TITLE
CPUデータベース create,update方法変更

### DIFF
--- a/app/controllers/cpus_controller.rb
+++ b/app/controllers/cpus_controller.rb
@@ -1,9 +1,10 @@
 class CpusController < ApplicationController
+
   def create
     @parts_lists = []
-    Cpu.all.destroy_all
     get_cpu
     save_cpu
+    redirect_to pcpart_path(1)
   end
 
   private
@@ -92,7 +93,8 @@ class CpusController < ApplicationController
 
     def save_cpu
       @parts_lists.each do |parts_list|
-        @cpu = Cpu.new(
+        cpu_list = Cpu.find_or_initialize_by(item_value: parts_list[4])
+        cpu_list.update_attributes(
           name: parts_list[1],
           brand: parts_list[0],
           processor: parts_list[2],
@@ -100,7 +102,6 @@ class CpusController < ApplicationController
           pcpart_id: 1,
           item_value: parts_list[4]
         )
-        @cpu.save
       end
     end
 

--- a/app/controllers/cpus_controller.rb
+++ b/app/controllers/cpus_controller.rb
@@ -22,6 +22,7 @@ class CpusController < ApplicationController
       list10 = [] #["マルチスレッド"]
       list11 = [] #["TDP"]
       list12 = [] #["画像"]
+      list13 = [] #["個別ID"]
       Anemone.crawl("https://kakaku.com/specsearch/0510/?st=2&_s=2&DispNonPrice=on&Sort=saledate_desc&DispSaleDate=on&", :depth_limit => 0) do |anemone|
         anemone.on_every_page do |page|
 
@@ -77,9 +78,14 @@ class CpusController < ApplicationController
           #   list12.push(title.to_s)
           # end
 
-          # リスト1~12を結合（各製品毎に配列をまとめる。多重配列になる）
-          # list0 = list1.zip(list2, list3, list4, list5, list6, list7, list8, list9, list10, list11, list12)
-          @parts_lists = list1.zip(list2, list3, list4)
+          # 個別IDを抜き出してlist13に入れる
+          page.doc.xpath("//input[contains(@value, 'K')]/@value").each do |title|
+            list13.push(title.to_s)
+          end
+
+          # リスト1~13を結合（各製品毎に配列をまとめる。多重配列になる）
+          # list0 = list1.zip(list2, list3, list4, list5, list6, list7, list8, list9, list10, list11, list12, list13)
+          @parts_lists = list1.zip(list2, list3, list4, list13)
         end
       end
     end
@@ -91,7 +97,8 @@ class CpusController < ApplicationController
           brand: parts_list[0],
           processor: parts_list[2],
           socket: parts_list[3],
-          pcpart_id: 1
+          pcpart_id: 1,
+          item_value: parts_list[4]
         )
         @cpu.save
       end

--- a/app/controllers/parts_lists_controller.rb
+++ b/app/controllers/parts_lists_controller.rb
@@ -1,2 +1,3 @@
 class PartsListsController < ApplicationController
+  
 end

--- a/app/controllers/parts_lists_controller.rb
+++ b/app/controllers/parts_lists_controller.rb
@@ -1,3 +1,6 @@
 class PartsListsController < ApplicationController
-  
+  def index
+    @user = User.find(params[:user_id])
+    @lists = @user.parts_lists.includes(:user)
+  end
 end

--- a/app/models/hdd.rb
+++ b/app/models/hdd.rb
@@ -1,3 +1,4 @@
 class Hdd < ApplicationRecord
+  has_many :parts_lists
   belongs_to :pcpart
 end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -1,3 +1,4 @@
 class Memory < ApplicationRecord
+  has_many :parts_lists
   belongs_to :pcpart
 end

--- a/app/models/parts_list.rb
+++ b/app/models/parts_list.rb
@@ -1,12 +1,12 @@
 class PartsList < ApplicationRecord
   belongs_to :cpu
   belongs_to :mb
-  belongs_to :
-  belongs_to :
-  belongs_to :
-  belongs_to :
-  belongs_to :
-  belongs_to :
-  belongs_to :
-  belongs_to :
+  belongs_to :hdd
+  belongs_to :ssd
+  belongs_to :videocard
+  belongs_to :power
+  belongs_to :pccase
+  belongs_to :cpucooler
+  belongs_to :display
+  belongs_to :user
 end

--- a/app/models/parts_list.rb
+++ b/app/models/parts_list.rb
@@ -1,4 +1,12 @@
 class PartsList < ApplicationRecord
   belongs_to :cpu
   belongs_to :mb
+  belongs_to :
+  belongs_to :
+  belongs_to :
+  belongs_to :
+  belongs_to :
+  belongs_to :
+  belongs_to :
+  belongs_to :
 end

--- a/app/models/power.rb
+++ b/app/models/power.rb
@@ -1,2 +1,3 @@
 class Power < ApplicationRecord
+  has_many :parts_lists
 end

--- a/app/models/ssd.rb
+++ b/app/models/ssd.rb
@@ -1,3 +1,4 @@
 class Ssd < ApplicationRecord
+  has_many :parts_lists
   belongs_to :pcpart
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :parts_lists
 end

--- a/app/models/videocard.rb
+++ b/app/models/videocard.rb
@@ -1,3 +1,4 @@
 class Videocard < ApplicationRecord
+  has_many :parts_lists
   belongs_to :pcpart
 end

--- a/app/views/parts_lists/index.html.haml
+++ b/app/views/parts_lists/index.html.haml
@@ -2,25 +2,7 @@
   .header
     = render "header"
   .main
-    .side-bar
-      .parts-list
-        = link_to "#", class: "parts-list__category" do
-          CPU
-        = link_to "#", class: "parts-list__category" do
-          マザーボード
-        = link_to "#", class: "parts-list__category" do
-          HDD
     .contents
-      .contents-top
-        .contents-top__name
-          カテゴリー：CPU
-        .contents-top__list
-          パーツリスト：リスト1番
-      .contents-main
-        .content
-        .content
-        .content
-        .content
-
-  -# .footer
-  -#   このサイトについて
+      .partslist-content
+        - @lists.each do |list|
+          = list.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,7 @@ Rails.application.routes.draw do
     resources :cpus, only: [:index, :create]
     resources :mbs, only: :index
   end
+  resources :users, only: :show do
+    resources :parts_lists, only: [:new]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
     resources :mbs, only: :index
   end
   resources :users, only: :show do
-    resources :parts_lists, only: [:new]
+    resources :parts_lists, only: [:index, :new]
   end
 end

--- a/db/migrate/20191121084347_addmemory_to_parts_lists.rb
+++ b/db/migrate/20191121084347_addmemory_to_parts_lists.rb
@@ -1,0 +1,12 @@
+class AddmemoryToPartsLists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :parts_lists, :memory_id,      :integer, after: :mb_id
+    add_column :parts_lists, :hdd_id,         :integer, after: :memory_id
+    add_column :parts_lists, :ssd_id,         :integer, after: :hdd_id
+    add_column :parts_lists, :videocard_id,   :integer, after: :ssd_id
+    add_column :parts_lists, :powersupply_id, :integer, after: :videocard_id
+    add_column :parts_lists, :pccase_id,      :integer, after: :powersupply_id
+    add_column :parts_lists, :cpucooler_id,   :integer, after: :pccase_id
+    add_column :parts_lists, :display_id,     :integer, after: :cpucooler_id
+  end
+end

--- a/db/migrate/20191121105553_add_item_value_to_cpu.rb
+++ b/db/migrate/20191121105553_add_item_value_to_cpu.rb
@@ -1,0 +1,5 @@
+class AddItemValueToCpu < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cpus, :item_value, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_123148) do
+ActiveRecord::Schema.define(version: 2019_11_21_084347) do
 
   create_table "cpucoolers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -85,6 +85,14 @@ ActiveRecord::Schema.define(version: 2019_11_20_123148) do
     t.boolean "public_private", null: false
     t.integer "cpu_id"
     t.integer "mb_id"
+    t.integer "memory_id"
+    t.integer "hdd_id"
+    t.integer "ssd_id"
+    t.integer "videocard_id"
+    t.integer "powersupply_id"
+    t.integer "pccase_id"
+    t.integer "cpucooler_id"
+    t.integer "display_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_21_084347) do
+ActiveRecord::Schema.define(version: 2019_11_21_105553) do
 
   create_table "cpucoolers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2019_11_21_084347) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pcpart_id"
+    t.string "item_value"
   end
 
   create_table "displays", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/kakaku.rb
+++ b/kakaku.rb
@@ -14,6 +14,7 @@ Anemone.crawl("https://kakaku.com/specsearch/0510/?st=2&_s=2&DispNonPrice=on&Sor
     list10 = [] #["マルチスレッド"]
     list11 = [] #["TDP"]
     list12 = [] #["画像"]
+    list13 = []
 
     # メーカー名と製品名はテーブルの同じセルに記載されているため他と処理を分ける
 
@@ -21,70 +22,78 @@ Anemone.crawl("https://kakaku.com/specsearch/0510/?st=2&_s=2&DispNonPrice=on&Sor
     page.doc.xpath("//td[contains(@class, 'textL')]").each do |title|
       list1.push(title.elements[0].text)
     end
-    # 製品名を抜き出してlist2に入れる
-    page.doc.xpath("//td[contains(@class, 'textL')]").each do |title|
-      list2.push(title.elements[2].text)
+
+    # 個別IDを抜き出してlist13に入れる
+    page.doc.xpath("//input[contains(@value, 'K')]/@value").each do |title|
+      list13.push(title.to_s)
     end
 
-    # ソケット形状を抜き出してlist3に入れる
-    page.doc.xpath("//label[contains(@title, 'ソケット形状')]").each do |title|
-      list3.push(title.text)
-    end
 
-    # コア数を抜き出してlist4に入れる
-    page.doc.xpath("//label[contains(@title, 'コア数')]").each do |title|
-      list4.push(title.text)
-    end
+    # # 製品名を抜き出してlist2に入れる
+    # page.doc.xpath("//td[contains(@class, 'textL')]").each do |title|
+    #   list2.push(title.elements[2].text)
+    # end
 
-    # スレッド数を抜き出してlist5に入れる
-    page.doc.xpath("//label[contains(@title, 'スレッド数')]").each do |title|
-      list5.push(title.text)
-    end
+    # # ソケット形状を抜き出してlist3に入れる
+    # page.doc.xpath("//label[contains(@title, 'ソケット形状')]").each do |title|
+    #   list3.push(title.text)
+    # end
 
-    # クロック周波数を抜き出してlist6に入れる
-    page.doc.xpath("//label[contains(@title, 'クロック周波数')]").each do |title|
-      list6.push(title.text)
-    end
+    # # コア数を抜き出してlist4に入れる
+    # page.doc.xpath("//label[contains(@title, 'コア数')]").each do |title|
+    #   list4.push(title.text)
+    # end
 
-    # 最大動作クロック周波数を抜き出してlist7に入れる
-    page.doc.xpath("//label[contains(@title, '最大動作クロック周波数')]").each do |title|
-      list7.push(title.text)
-    end
+    # # スレッド数を抜き出してlist5に入れる
+    # page.doc.xpath("//label[contains(@title, 'スレッド数')]").each do |title|
+    #   list5.push(title.text)
+    # end
 
-    # 二次キャッシュを抜き出してlist8に入れる
-    page.doc.xpath("//label[contains(@title, '二次キャッシュ')]").each do |title|
-      list8.push(title.text)
-    end
+    # # クロック周波数を抜き出してlist6に入れる
+    # page.doc.xpath("//label[contains(@title, 'クロック周波数')]").each do |title|
+    #   list6.push(title.text)
+    # end
 
-    # 三次キャッシュを抜き出してlist9に入れる
-    page.doc.xpath("//label[contains(@title, '三次キャッシュ')]").each do |title|
-      list9.push(title.text)
-    end
+    # # 最大動作クロック周波数を抜き出してlist7に入れる
+    # page.doc.xpath("//label[contains(@title, '最大動作クロック周波数')]").each do |title|
+    #   list7.push(title.text)
+    # end
 
-    # マルチスレッドを抜き出してlist10に入れる
-    page.doc.xpath("//label[contains(@title, 'マルチスレッド')]").each do |title|
-      list10.push(title.text)
-    end
+    # # 二次キャッシュを抜き出してlist8に入れる
+    # page.doc.xpath("//label[contains(@title, '二次キャッシュ')]").each do |title|
+    #   list8.push(title.text)
+    # end
 
-    # TDPを抜き出してlist11に入れる
-    page.doc.xpath("//label[contains(@title, 'TDP')]").each do |title|
-      list11.push(title.text)
-    end
+    # # 三次キャッシュを抜き出してlist9に入れる
+    # page.doc.xpath("//label[contains(@title, '三次キャッシュ')]").each do |title|
+    #   list9.push(title.text)
+    # end
 
-    # 画像URLを抜き出してlist12に入れる
-    page.doc.xpath("//img[contains(@src, '.jpg') or contains(@src, 'nowprinting.gif')]/@src").each do |title|
-      title = "no image" if title.to_s.match(/.gif/)
-      list12.push(title.to_s)
-    end
+    # # マルチスレッドを抜き出してlist10に入れる
+    # page.doc.xpath("//label[contains(@title, 'マルチスレッド')]").each do |title|
+    #   list10.push(title.text)
+    # end
+
+    # # TDPを抜き出してlist11に入れる
+    # page.doc.xpath("//label[contains(@title, 'TDP')]").each do |title|
+    #   list11.push(title.text)
+    # end
+
+    # # 画像URLを抜き出してlist12に入れる
+    # page.doc.xpath("//img[contains(@src, '.jpg') or contains(@src, 'nowprinting.gif')]/@src").each do |title|
+    #   title = "no image" if title.to_s.match(/.gif/)
+    #   list12.push(title.to_s)
+    # end
 
     # リスト1~12を結合（各製品毎に配列をまとめる。多重配列になる）
     # list0 = list1.zip(list2, list3, list4, list5, list6, list7, list8, list9, list10, list11, list12)
-    list0 = list1.zip(list2, list3, list4)
-    # p list0[0]
+    # list0 = list1.zip(list2, list3, list4)
+    list0 = list1.zip(list13)
+    p list0
     # 多重配列を1行ずつ製品毎に書き出し
-    list0.each do |list|
-      p list
-    end
+    # list0.each do |list|
+    #   p list
+    # end
 
 
   end


### PR DESCRIPTION
# What
CPUデータベースのcreateアクションの保存方法を変更する
- 変更前
  - データベースをdelete_allで空にして再度スクレイピングしたデータを保存
- 変更後
  - update_attributesメソッドで新規作成と更新を切り分けた 
# Why
変更前の方法だとデータを更新する度に新規作成されるためIDがどんどん更新される
パーツリストを作成するときに、各パーツのIDを保存してもIDが変わる(古いのは削除される)から参照できなくなる
上記の問題を解決するためにcreateアクションの保存方法を変更する