### PR TITLE
ログイン/未ログイン時の処理を修正

### DIFF
--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -41,6 +41,25 @@
     }
   }
 
+  .notifications {
+    color: white;
+    text-align: center;
+    .notice {
+      height: 60px;
+      line-height: 60px;
+      font-size: 36px;
+      background-color: #3456f7;
+      text-align: center;
+    }
+
+    .alert {
+      height: 60px;
+      line-height: 60px;
+      font-size: 36px;
+      background-color: #ef1a1f;
+    }
+  }
+
   .main{
     color: $main_color;
     background-color: $main-bgc;

--- a/app/assets/stylesheets/pcpart.scss
+++ b/app/assets/stylesheets/pcpart.scss
@@ -49,19 +49,25 @@
     }
   }
 
-  .add-btn{
-    box-sizing: border-box;
-    color: #FFF;
-    background: #fd9535;
-    height: 60px;
-    width: 200px;
-    margin-bottom: 5px;
-    font-size: 24px;
-    font-weight: bold;
-    border-radius: 4px;
-    border: solid 2px #d27d00;
-    box-shadow: inset 0 2px 0 rgba(255,255,255,0.4), inset 0 -2px 0 rgba(0, 0, 0, 0.15);
-    cursor: pointer;
+  .content-top{
+    display: flex;
+    .add-btn{
+      box-sizing: border-box;
+      color: #FFF;
+      background: #fd9535;
+      height: 60px;
+      width: 200px;
+      margin-bottom: 5px;
+      font-size: 24px;
+      font-weight: bold;
+      border-radius: 4px;
+      border: solid 2px #d27d00;
+      box-shadow: inset 0 2px 0 rgba(255,255,255,0.4), inset 0 -2px 0 rgba(0, 0, 0, 0.15);
+      cursor: pointer;
+    }
+    .content-clearbox{
+      height: 60px;
+    }
   }
 
 }

--- a/app/controllers/parts_lists_controller.rb
+++ b/app/controllers/parts_lists_controller.rb
@@ -1,4 +1,7 @@
 class PartsListsController < ApplicationController
+  before_action :signed_in_user
+  before_action :only_current_user
+
   def index
     @user = User.find(params[:user_id])
     @lists = @user.parts_lists.includes(:user)
@@ -40,6 +43,18 @@ class PartsListsController < ApplicationController
   private
     def parts_list_params
       params.permit(:name, :cpu_id, :mb_id, :memory_id, :hdd_id, :ssd_id, :videocard_id, :power_id, :pccase_id, :cpucooler_id, :display_id).merge(public_private: 1).merge(user_id: current_user.id)
+    end
+
+    def signed_in_user
+      unless signed_in?
+        redirect_to root_path
+        flash[:alert] = "ログインして下さい"
+      end
+    end
+
+    def only_current_user
+      @user = User.find(params[:user_id])
+      redirect_to user_parts_lists_path(current_user.id) unless current_user == @user
     end
 
 end

--- a/app/controllers/parts_lists_controller.rb
+++ b/app/controllers/parts_lists_controller.rb
@@ -27,6 +27,7 @@ class PartsListsController < ApplicationController
       redirect_to user_parts_lists_path(current_user.id)
     else
       redirect_to user_parts_lists_path(current_user.id)
+      flash[:alert] = "パーツリストがありません"
     end
   end
 

--- a/app/controllers/parts_lists_controller.rb
+++ b/app/controllers/parts_lists_controller.rb
@@ -20,13 +20,14 @@ class PartsListsController < ApplicationController
   end
 
   def update
-    # binding.pry
-    params[:id] = params[:list_id] if :list_id
-    @parts_list = PartsList.find(params[:id])
-    @parts_list.update(parts_list_params)
-    # @parts_list.update(params[:hdd_id])
-    # binding.pry
-    redirect_to user_parts_lists_path(current_user.id)
+    if params[:list_id]
+      params[:id] = params[:list_id]
+      @parts_list = PartsList.find(params[:id])
+      @parts_list.update(parts_list_params)
+      redirect_to user_parts_lists_path(current_user.id)
+    else
+      redirect_to user_parts_lists_path(current_user.id)
+    end
   end
 
   def destroy

--- a/app/controllers/pcparts_controller.rb
+++ b/app/controllers/pcparts_controller.rb
@@ -4,7 +4,7 @@ class PcpartsController < ApplicationController
 
   def show
     @category = Pcpart.find(params[:id])
-    @parts_lists = PartsList.includes(:user)
+    @parts_lists = PartsList.includes(:user).where(user_id: current_user.id)
     case @category.category
     when "CPU"
       @cpus = @category.cpus

--- a/app/controllers/pcparts_controller.rb
+++ b/app/controllers/pcparts_controller.rb
@@ -4,7 +4,8 @@ class PcpartsController < ApplicationController
 
   def show
     @category = Pcpart.find(params[:id])
-    @parts_lists = PartsList.includes(:user).where(user_id: current_user.id)
+    @parts_lists = PartsList.includes(:user).where(user_id: current_user.id) if user_signed_in?
+
     case @category.category
     when "CPU"
       @cpus = @category.cpus

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,3 @@
+.notifications
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: key)

--- a/app/views/parts_lists/index.html.haml
+++ b/app/views/parts_lists/index.html.haml
@@ -1,6 +1,9 @@
 .wrapper
   .header
     = render "header"
+
+  = render 'layouts/notifications'
+
   .main
     .contents
       .partslists__controller

--- a/app/views/pcparts/category/_cpu.html.haml
+++ b/app/views/pcparts/category/_cpu.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-4th.th-name= cpu.name

--- a/app/views/pcparts/category/_cpucooler.html.haml
+++ b/app/views/pcparts/category/_cpucooler.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: cpucooler.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-5th.th-name= cpucooler.name

--- a/app/views/pcparts/category/_display.html.haml
+++ b/app/views/pcparts/category/_display.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: display.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-5th.th-name= display.name

--- a/app/views/pcparts/category/_hdd.html.haml
+++ b/app/views/pcparts/category/_hdd.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: hdd.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-6th.th-name= hdd.name

--- a/app/views/pcparts/category/_mb.html.haml
+++ b/app/views/pcparts/category/_mb.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: mb.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-5th.th-name= mb.name

--- a/app/views/pcparts/category/_memory.html.haml
+++ b/app/views/pcparts/category/_memory.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: memory.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-5th.th-name= memory.name

--- a/app/views/pcparts/category/_pccase.html.haml
+++ b/app/views/pcparts/category/_pccase.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: pccase.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-5th.th-name= pccase.name

--- a/app/views/pcparts/category/_power.html.haml
+++ b/app/views/pcparts/category/_power.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: power.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-4th.th-name= power.name

--- a/app/views/pcparts/category/_ssd.html.haml
+++ b/app/views/pcparts/category/_ssd.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: ssd.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-5th.th-name= ssd.name

--- a/app/views/pcparts/category/_videocard.html.haml
+++ b/app/views/pcparts/category/_videocard.html.haml
@@ -1,5 +1,8 @@
 .content
-  = f.submit name: videocard.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+  .content-top
+    - if user_signed_in?
+      = f.submit name: cpu.id, class: "add-btn", value: "リストに追加", "data-disable-with":"リストに追加"
+    .content-clearbox
   %table.parts__table
     %tr.parts__table__head__tr
       %th.th-5th.th-name= videocard.name

--- a/app/views/pcparts/show.html.haml
+++ b/app/views/pcparts/show.html.haml
@@ -9,22 +9,18 @@
       = form_with(model: @parts_list,
         local: true,
         method: :patch,
-        url: user_parts_list_path(current_user.id),
+        url: user_signed_in? ? user_parts_list_path(current_user.id) : nil,
         class: "contents-top__list__select") do |f|
         .contents-top
           .contents-top__name
             = "カテゴリー：#{@category.category}"
-            -# = @category.id
-            = render "updatedb"
-          - if current_user
+            - if user_signed_in?
+              = render "updatedb"
+          - if user_signed_in?
             .contents-top__list
-              -# = form_for(@parts_lists) do |f|
               %p.list-title パーツリスト
               .select-list
                 = f.select :list_id, @parts_lists.map { |parts_list| [parts_list.name, parts_list.id] }, selected: params[:list_id]
-              -# = f.submit
-              -# = f.hidden_field :hdd_id, value: "1"
-              -# - binding.pry
         .contents-main
           - case @category.id
           - when 1


### PR DESCRIPTION
# What
- ログイン状態で処理を場合分け
 - 未ログインユーザーがユーザー画面に行けないよう修正
 - 他のユーザーのユーザー画面に行けないよう修正
  - 未ログイン時にcurrento_userを参照できない問題を修正
  - リストに追加ボタンなどを未ログイン時は非表示に変更
# Why
- 未ログイン時エラーが生じるため修正する