### PR TITLE
パーツリスト スクロールバーをx方向だけ表示

### DIFF
--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -26,7 +26,9 @@ $(function(){
       </div>
       <div class="show-list__head">
         <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.cpu.image}" width="120" height="120"></div>
-        <div class="show-image-name">${partsList.cpu.name}</div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content">${partsList.cpu.name}</div>
+        </div>
       </div>
         <div class="show-list__head">
           <div class="show-key">メーカー</div>
@@ -80,7 +82,9 @@ $(function(){
         </div>
         <div class="show-list__head">
           <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.mb.image}" width="120" height="120"></div>
-          <div class="show-image-name">${partsList.mb.name}</div>
+          <div class="show-image-name-box">
+            <div class="show-image-name-content">${partsList.mb.name}</div>
+          </div>
         </div>
         <div class="show-list__head">
           <div class="show-key">メーカー</div>
@@ -142,7 +146,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.memory.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.memory.name}</div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content">${partsList.memory.name}</div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -204,41 +210,6 @@ $(function(){
     return html
   }
 
-  function HiddenMemory(){
-    var html = `
-      <div class="show-list hidden">
-      <div class="show-list__head">
-      <div class="show-title">メモリー</div>
-      </div>
-      <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
-      </div>
-      <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
-      </div>
-      <div class="show-list__head">
-      <div class="show-key">メモリ容量(1枚あたり)</div>
-      <div class="show-value"></div>
-      </div>
-      <div class="show-list__head">
-      <div class="show-key">枚数</div>
-      <div class="show-value"></div>
-      </div>
-      <div class="show-list__head">
-      <div class="show-key">メモリ規格</div>
-      <div class="show-value"></div>
-      </div>
-      <div class="show-list__head">
-      <div class="show-key">メモリインターフェイス</div>
-      <div class="show-value"></div>
-      </div>
-      </div>
-    `
-    return html
-  }
-
   function buildPartsListHdd(partsList){
     var html = `
       <div class="show-list">
@@ -247,7 +218,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.hdd.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.hdd.name}</div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content">${partsList.hdd.name}</div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -333,7 +306,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.ssd.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.ssd.name}</div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content">${partsList.ssd.name}</div>
+        </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -403,7 +378,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.videocard.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.videocard.name}</div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content">${partsList.videocard.name}</div>
+        </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -481,7 +458,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.power.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.power.name}</div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content">${partsList.power.name}</div>
+        </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -543,7 +522,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.pccase.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.pccase.name}</div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content">${partsList.pccase.name}</div>
+        </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -605,7 +586,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.cpucooler.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.cpucooler.name}</div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content">${partsList.cpucooler.name}</div>
+        </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -675,7 +658,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.display.image}" width="120" height="120"></div>
-      <div class="show-image-name">${partsList.display.name}</div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content">${partsList.display.name}</div>
+        </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>

--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -55,7 +55,9 @@ $(function(){
       </div>
       <div class="show-list__head">
         <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-        <div class="show-image-name"></div>
+        <div class="show-image-name-box">
+          <div class="show-image-name-content"></div>
+        </div>
       </div>
         <div class="show-list__head">
           <div class="show-key">メーカー</div>
@@ -115,7 +117,9 @@ $(function(){
         </div>
         <div class="show-list__head">
           <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-          <div class="show-image-name"></div>
+          <div class="show-image-name-box">
+            <div class="show-image-name-content"></div>
+          </div>
         </div>
         <div class="show-list__head">
           <div class="show-key">メーカー</div>
@@ -183,7 +187,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -263,7 +269,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -343,7 +351,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -419,7 +429,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -491,7 +503,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -555,7 +569,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -623,7 +639,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>
@@ -695,7 +713,9 @@ $(function(){
       </div>
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="https://placehold.jp/150x150.png" width="120" height="120"></div>
-      <div class="show-image-name"></div>
+      <div class="show-image-name-box">
+        <div class="show-image-name-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
       <div class="show-key">メーカー</div>

--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -31,16 +31,28 @@ $(function(){
         </div>
       </div>
         <div class="show-list__head">
-          <div class="show-key">メーカー</div>
-          <div class="show-value">${partsList.cpu.brand}</div>
+          <div class="show-key-box">
+            <div class="show-key-content">メーカー</div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content">${partsList.cpu.brand}</div>
+          </div>
         </div>
       <div class="show-list__head">
-        <div class="show-key">プロセッサー</div>
-        <div class="show-value">${partsList.cpu.processor}</div>
+        <div class="show-key-box">
+          <div class="show-key-content">プロセッサー</div>
+        </div>
+        <div class="show-value-box">
+          <div class="show-value-content">${partsList.cpu.processor}</div>
+        </div>
       </div>
       <div class="show-list__head">
-        <div class="show-key">ソケット形状</div>
-        <div class="show-value">${partsList.cpu.socket}</div>
+        <div class="show-key-box">
+          <div class="show-key-content">ソケット形状</div>
+        </div>
+        <div class="show-value-box">
+          <div class="show-value-content">${partsList.cpu.socket}</div>
+        </div>
       </div>
     </div>
     `
@@ -60,16 +72,28 @@ $(function(){
         </div>
       </div>
         <div class="show-list__head">
-          <div class="show-key">メーカー</div>
-          <div class="show-value"></div>
+          <div class="show-key-box">
+            <div class="show-key-content">メーカー</div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content"></div>
+          </div>
         </div>
       <div class="show-list__head">
-        <div class="show-key">プロセッサー</div>
-        <div class="show-value"></div>
+        <div class="show-key-box">
+          <div class="show-key-content">プロセッサー</div>
+        </div>
+        <div class="show-value-box">
+          <div class="show-value-content"></div>
+        </div>
       </div>
       <div class="show-list__head">
-        <div class="show-key">ソケット形状</div>
-        <div class="show-value"></div>
+        <div class="show-key-box">
+          <div class="show-key-content">ソケット形状</div>
+        </div>
+        <div class="show-value-box">
+          <div class="show-value-content"></div>
+        </div>
       </div>
     </div>
     `
@@ -89,20 +113,36 @@ $(function(){
           </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">メーカー</div>
-          <div class="show-value">${partsList.mb.brand}</div>
+          <div class="show-key-box">
+            <div class="show-key-content">メーカー</div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content">${partsList.mb.brand}</div>
+          </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">チップセット</div>
-          <div class="show-value">${partsList.mb.chipset}</div>
+          <div class="show-key-box">
+            <div class="show-key-content">チップセット</div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content">${partsList.mb.chipset}</div>
+          </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">フォームファクタ</div>
-          <div class="show-value">${partsList.mb.formfactor}</div>
+          <div class="show-key-box">
+            <div class="show-key-content">フォームファクタ</div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content">${partsList.mb.formfactor}</div>
+          </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">ソケット形状</div>
-          <div class="show-value">${partsList.mb.socket}</div>
+          <div class="show-key-box">
+            <div class="show-key-content">ソケット形状</div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content">${partsList.mb.socket}</div>
+          </div>
         </div>
       </div>
     `
@@ -122,20 +162,36 @@ $(function(){
           </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">メーカー</div>
-          <div class="show-value"></div>
+          <div class="show-key-box">
+            <div class="show-key-content"></div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content"></div>
+          </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">チップセット</div>
-          <div class="show-value"></div>
+          <div class="show-key-box">
+            <div class="show-key-content"></div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content"></div>
+          </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">フォームファクタ</div>
-          <div class="show-value"></div>
+          <div class="show-key-box">
+            <div class="show-key-content"></div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content"></div>
+          </div>
         </div>
         <div class="show-list__head">
-          <div class="show-key">ソケット形状</div>
-          <div class="show-value"></div>
+          <div class="show-key-box">
+            <div class="show-key-content"></div>
+          </div>
+          <div class="show-value-box">
+            <div class="show-value-content"></div>
+          </div>
         </div>
       </div>
     `
@@ -155,24 +211,44 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.memory.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.memory.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリ容量(1枚あたり)</div>
-      <div class="show-value">${partsList.memory.capacity}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メモリ容量(1枚あたり)</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.memory.capacity}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">枚数</div>
-      <div class="show-value">${partsList.memory.setnumber}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">枚数</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.memory.setnumber}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリ規格</div>
-      <div class="show-value">${partsList.memory.standard}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メモリ規格</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.memory.standard}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリインターフェイス</div>
-      <div class="show-value">${partsList.memory.interface}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メモリインターフェイス</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.memory.interface}</div>
+      </div>
       </div>
       </div>
     `
@@ -192,24 +268,44 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリ容量(1枚あたり)</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">枚数</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリ規格</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリインターフェイス</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `
@@ -225,36 +321,64 @@ $(function(){
       <div class="show-list__head">
       <div class="show-image"><img alt="No Image" class="td-image" src="${partsList.hdd.image}" width="120" height="120"></div>
       <div class="show-image-name-box">
-        <div class="show-image-name-content">${partsList.hdd.name}</div>
+      <div class="show-image-name-content">${partsList.hdd.name}</div>
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.hdd.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.hdd.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">シリーズ</div>
-      <div class="show-value">${partsList.hdd.series}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">シリーズ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.hdd.series}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">容量</div>
-      <div class="show-value">${partsList.hdd.capacity}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">容量</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.hdd.capacity}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">回転数</div>
-      <div class="show-value">${partsList.hdd.speed}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">回転数</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.hdd.speed}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">インターフェイス</div>
-      <div class="show-value">${partsList.hdd.interface1}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">インターフェイス</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.hdd.interface1}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">インターフェイス</div>
-      <div class="show-value">${partsList.hdd.interface2}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">インターフェイス</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.hdd.interface2}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">キャッシュ</div>
-      <div class="show-value">${partsList.hdd.cache}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">キャッシュ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.hdd.cache}</div>
+      </div>
       </div>
       </div>
     `
@@ -274,32 +398,60 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">シリーズ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">容量</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">回転数</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">インターフェイス</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">インターフェイス</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">キャッシュ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `
@@ -319,24 +471,44 @@ $(function(){
         </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.ssd.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.ssd.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">容量</div>
-      <div class="show-value">${partsList.ssd.capacity}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">容量</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.ssd.capacity}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">規格サイズ</div>
-      <div class="show-value">${partsList.ssd.size}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">規格サイズ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.ssd.size}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">インターフェイス</div>
-      <div class="show-value">${partsList.ssd.interface}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">インターフェイス</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.ssd.interface}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">タイプ</div>
-      <div class="show-value">${partsList.ssd.ssdtype}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">タイプ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.ssd.ssdtype}</div>
+      </div>
       </div>
       </div>
     `
@@ -356,24 +528,44 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">容量</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">規格サイズ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">インターフェイス</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">タイプ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `
@@ -393,28 +585,52 @@ $(function(){
         </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.videocard.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.videocard.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">搭載チップ</div>
-      <div class="show-value">${partsList.videocard.chip}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">搭載チップ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.videocard.chip}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">CUDAコア数</div>
-      <div class="show-value">${partsList.videocard.core}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">CUDAコア数</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.videocard.core}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリ</div>
-      <div class="show-value">${partsList.videocard.memory}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メモリ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.videocard.memory}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリクロック</div>
-      <div class="show-value">${partsList.videocard.clock}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メモリクロック</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.videocard.clock}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">バスインターフェイス</div>
-      <div class="show-value">${partsList.videocard.interface}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">バスインターフェイス</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.videocard.interface}</div>
+      </div>
       </div>
       </div>
     `
@@ -434,28 +650,52 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">搭載チップ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">CUDAコア数</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メモリクロック</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">バスインターフェイス</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `
@@ -475,20 +715,36 @@ $(function(){
         </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.power.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.power.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">対応規格</div>
-      <div class="show-value">${partsList.power.standard}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">対応規格</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.power.standard}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">電源容量</div>
-      <div class="show-value">${partsList.power.capacity}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">電源容量</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.power.capacity}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">80PLUS認証</div>
-      <div class="show-value">${partsList.power.plus}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">80PLUS認証</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.power.plus}</div>
+      </div>
       </div>
       </div>
     `
@@ -508,20 +764,36 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">対応規格</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">電源容量</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">80PLUS認証</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `
@@ -541,20 +813,36 @@ $(function(){
         </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.pccase.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.pccase.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">対応ファクター</div>
-      <div class="show-value">${partsList.pccase.factor}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">対応ファクター</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.pccase.factor}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">重量</div>
-      <div class="show-value">${partsList.pccase.weight}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">重量</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.pccase.weight}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">幅x高さx奥行</div>
-      <div class="show-value">${partsList.pccase.size_wdh}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">幅x高さx奥行</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.pccase.size_wdh}</div>
+      </div>
       </div>
       </div>
     `
@@ -574,20 +862,36 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">対応ファクター</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">重量</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">幅x高さx奥行</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `
@@ -607,24 +911,44 @@ $(function(){
         </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.cpucooler.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.cpucooler.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">Intel対応ソケット</div>
-      <div class="show-value">${partsList.cpucooler.intel}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">Intel対応ソケット</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.cpucooler.intel}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">AMD対応ソケット</div>
-      <div class="show-value">${partsList.cpucooler.amd}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">AMD対応ソケット</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.cpucooler.amd}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">タイプ</div>
-      <div class="show-value">${partsList.cpucooler.flowtype}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">タイプ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.cpucooler.flowtype}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">ノイズレベル</div>
-      <div class="show-value">${partsList.cpucooler.noise}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">ノイズレベル</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.cpucooler.noise}</div>
+      </div>
       </div>
       </div>
     `
@@ -644,24 +968,44 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">Intel対応ソケット</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">AMD対応ソケット</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">タイプ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">ノイズレベル</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `
@@ -681,24 +1025,44 @@ $(function(){
         </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value">${partsList.display.brand}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">メーカー</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.display.brand}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">モニタサイズ</div>
-      <div class="show-value">${partsList.display.size}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">モニタサイズ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.display.size}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">モニタタイプ</div>
-      <div class="show-value">${partsList.display.monitortype}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">モニタタイプ</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.display.monitortype}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">表示領域</div>
-      <div class="show-value">${partsList.display.area}</div>
+      <div class="show-key-box">
+      <div class="show-key-content">表示領域</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.display.area}</div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">コントラスト比</div>
-      <div class="show-value">${partsList.display.contrast}/div>
+      <div class="show-key-box">
+      <div class="show-key-content">コントラスト比</div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content">${partsList.display.contrast}/div>
+      </div>
       </div>
       </div>
     `
@@ -718,24 +1082,44 @@ $(function(){
       </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">メーカー</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">モニタサイズ</div>
-      <div class="show-value">partsList.display.size}</div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">モニタタイプ</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">表示領域</div>
-      <div class="show-value"></div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       <div class="show-list__head">
-      <div class="show-key">コントラスト比</div>
-      <div class="show-value">/div>
+      <div class="show-key-box">
+      <div class="show-key-content"></div>
+      </div>
+      <div class="show-value-box">
+      <div class="show-value-content"></div>
+      </div>
       </div>
       </div>
     `

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -392,23 +392,27 @@
               overflow-x: auto;
               white-space: nowrap;
             }
-            .show-key{
+            .show-key-box{
               width: 20%;
               border-right: 1px solid #000;
               border-bottom: 1px solid #000;
               text-align: center;
               box-sizing: border-box;
               height: 60px;
+            }
+            .show-key-content{
               line-height: 60px;
               overflow-x: auto;
               white-space: nowrap;
             }
-            .show-value{
+            .show-value-box{
               width: 80%;
               border-bottom: 1px solid #000;
               padding-left: 10px;
               box-sizing: border-box;
               height: 60px;
+            }
+            .show-value-content{
               line-height: 60px;
               overflow-x: scroll;
               white-space: nowrap;

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -380,13 +380,15 @@
               text-align: center;
               box-sizing: border-box;
             }
-            .show-image-name{
+            .show-image-name-box{
               padding: 10px;
               height: 140px;
-              line-height: 120px;
               width: 80%;
               border-bottom: 1px solid #000;
               box-sizing: border-box;
+            }
+            .show-image-name-content{
+              line-height: 120px;
               overflow-x: auto;
               white-space: nowrap;
             }
@@ -409,7 +411,7 @@
               height: 60px;
               line-height: 60px;
               overflow-x: scroll;
-              // white-space: nowrap;
+              white-space: nowrap;
             }
           }
         }

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -398,6 +398,8 @@
               box-sizing: border-box;
               height: 60px;
               line-height: 60px;
+              overflow-x: auto;
+              white-space: nowrap;
             }
             .show-value{
               width: 80%;
@@ -406,6 +408,8 @@
               box-sizing: border-box;
               height: 60px;
               line-height: 60px;
+              overflow-x: scroll;
+              // white-space: nowrap;
             }
           }
         }

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -399,6 +399,7 @@
               text-align: center;
               box-sizing: border-box;
               height: 60px;
+              padding: 0 5px;
             }
             .show-key-content{
               line-height: 60px;

--- a/app/views/parts_lists/show.html.haml
+++ b/app/views/parts_lists/show.html.haml
@@ -33,7 +33,8 @@
                 .show-title= "CPU"
               .show-list__head
                 .show-image= image_tag "#{get_cpu(@parts_list.cpu_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_cpu(@parts_list.cpu_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_cpu(@parts_list.cpu_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_cpu(@parts_list.cpu_id).brand
@@ -50,7 +51,8 @@
                 .show-title= "マザーボード"
               .show-list__head
                 .show-image= image_tag "#{get_motherboard(@parts_list.mb_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_motherboard(@parts_list.mb_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_motherboard(@parts_list.mb_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_motherboard(@parts_list.mb_id).brand
@@ -70,7 +72,8 @@
                 .show-title= "メモリー"
               .show-list__head
                 .show-image= image_tag "#{get_memory(@parts_list.memory_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_memory(@parts_list.memory_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_memory(@parts_list.memory_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_memory(@parts_list.memory_id).brand
@@ -93,7 +96,8 @@
                 .show-title= "HDD"
               .show-list__head
                 .show-image= image_tag "#{get_hdd(@parts_list.hdd_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_hdd(@parts_list.hdd_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_hdd(@parts_list.hdd_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_hdd(@parts_list.hdd_id).brand
@@ -122,7 +126,8 @@
                 .show-title= "SSD"
               .show-list__head
                 .show-image= image_tag "#{get_ssd(@parts_list.ssd_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_ssd(@parts_list.ssd_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_ssd(@parts_list.ssd_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_ssd(@parts_list.ssd_id).brand
@@ -146,7 +151,8 @@
                 .show-title= "グラフィックボード"
               .show-list__head
                 .show-image= image_tag "#{get_videocard(@parts_list.videocard_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_videocard(@parts_list.videocard_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_videocard(@parts_list.videocard_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_videocard(@parts_list.videocard_id).brand
@@ -172,7 +178,8 @@
                 .show-title= "電源ユニット"
               .show-list__head
                 .show-image= image_tag "#{get_powersupply(@parts_list.power_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_powersupply(@parts_list.power_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_powersupply(@parts_list.power_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_powersupply(@parts_list.power_id).brand
@@ -192,7 +199,8 @@
                 .show-title= "PCケース"
               .show-list__head
                 .show-image= image_tag "#{get_pccase(@parts_list.pccase_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_pccase(@parts_list.pccase_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_pccase(@parts_list.pccase_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_pccase(@parts_list.pccase_id).brand
@@ -212,7 +220,8 @@
                 .show-title= "CPUクーラー"
               .show-list__head
                 .show-image= image_tag "#{get_cpucooler(@parts_list.cpucooler_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_cpucooler(@parts_list.cpucooler_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_cpucooler(@parts_list.cpucooler_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_cpucooler(@parts_list.cpucooler_id).brand
@@ -235,7 +244,8 @@
                 .show-title= "液晶ディスプレイ"
               .show-list__head
                 .show-image= image_tag "#{get_display(@parts_list.display_id).image}", size: "120x120", alt: "No Image", class: "td-image"
-                .show-image-name= get_display(@parts_list.display_id).name
+                .show-image-name-box
+                  .show-image-name-content= get_display(@parts_list.display_id).name
               .show-list__head
                 .show-key メーカー
                 .show-value= get_display(@parts_list.display_id).brand

--- a/app/views/parts_lists/show.html.haml
+++ b/app/views/parts_lists/show.html.haml
@@ -36,14 +36,20 @@
                 .show-image-name-box
                   .show-image-name-content= get_cpu(@parts_list.cpu_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_cpu(@parts_list.cpu_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_cpu(@parts_list.cpu_id).brand
               .show-list__head
-                .show-key プロセッサー
-                .show-value= get_cpu(@parts_list.cpu_id).processor
+                .show-key-box
+                  .show-key-content プロセッサー
+                .show-value-box
+                  .show-value-content= get_cpu(@parts_list.cpu_id).processor
               .show-list__head
-                .show-key ソケット形状
-                .show-value= get_cpu(@parts_list.cpu_id).socket
+                .show-key-box
+                  .show-key-content ソケット形状
+                .show-value-box
+                  .show-value-content= get_cpu(@parts_list.cpu_id).socket
 
           - if get_motherboard(@parts_list.mb_id)
             .show-list
@@ -54,17 +60,25 @@
                 .show-image-name-box
                   .show-image-name-content= get_motherboard(@parts_list.mb_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_motherboard(@parts_list.mb_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_motherboard(@parts_list.mb_id).brand
               .show-list__head
-                .show-key チップセット
-                .show-value= get_motherboard(@parts_list.mb_id).chipset
+                .show-key-box
+                  .show-key-content チップセット
+                .show-value-box
+                  .show-value-content= get_motherboard(@parts_list.mb_id).chipset
               .show-list__head
-                .show-key フォームファクタ
-                .show-value= get_motherboard(@parts_list.mb_id).formfactor
+                .show-key-box
+                  .show-key-content フォームファクタ
+                .show-value-box
+                  .show-value-content= get_motherboard(@parts_list.mb_id).formfactor
               .show-list__head
-                .show-key ソケット形状
-                .show-value= get_motherboard(@parts_list.mb_id).socket
+                .show-key-box
+                  .show-key-content ソケット形状
+                .show-value-box
+                  .show-value-content= get_motherboard(@parts_list.mb_id).socket
 
           - if get_memory(@parts_list.memory_id)
             .show-list
@@ -75,20 +89,30 @@
                 .show-image-name-box
                   .show-image-name-content= get_memory(@parts_list.memory_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_memory(@parts_list.memory_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_memory(@parts_list.memory_id).brand
               .show-list__head
-                .show-key メモリ容量(1枚あたり)
-                .show-value= get_memory(@parts_list.memory_id).capacity
+                .show-key-box
+                  .show-key-content メモリ容量(1枚あたり)
+                .show-value-box
+                  .show-value-content= get_memory(@parts_list.memory_id).capacity
               .show-list__head
-                .show-key 枚数
-                .show-value= get_memory(@parts_list.memory_id).setnumber
+                .show-key-box
+                  .show-key-content 枚数
+                .show-value-box
+                  .show-value-content= get_memory(@parts_list.memory_id).setnumber
               .show-list__head
-                .show-key メモリ規格
-                .show-value= get_memory(@parts_list.memory_id).standard
+                .show-key-box
+                  .show-key-content メモリ規格
+                .show-value-box
+                  .show-value-content= get_memory(@parts_list.memory_id).standard
               .show-list__head
-                .show-key メモリインターフェイス
-                .show-value= get_memory(@parts_list.memory_id).interface
+                .show-key-box
+                  .show-key-content メモリインターフェイス
+                .show-value-box
+                  .show-value-content= get_memory(@parts_list.memory_id).interface
 
           - if get_hdd(@parts_list.hdd_id)
             .show-list
@@ -99,26 +123,40 @@
                 .show-image-name-box
                   .show-image-name-content= get_hdd(@parts_list.hdd_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_hdd(@parts_list.hdd_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_hdd(@parts_list.hdd_id).brand
               .show-list__head
-                .show-key シリーズ
-                .show-value= get_hdd(@parts_list.hdd_id).series
+                .show-key-box
+                  .show-key-content シリーズ
+                .show-value-box
+                  .show-value-content= get_hdd(@parts_list.hdd_id).series
               .show-list__head
-                .show-key 容量
-                .show-value= get_hdd(@parts_list.hdd_id).capacity
+                .show-key-box
+                  .show-key-content 容量
+                .show-value-box
+                  .show-value-content= get_hdd(@parts_list.hdd_id).capacity
               .show-list__head
-                .show-key 回転数
-                .show-value= get_hdd(@parts_list.hdd_id).speed
+                .show-key-box
+                  .show-key-content 回転数
+                .show-value-box
+                  .show-value-content= get_hdd(@parts_list.hdd_id).speed
               .show-list__head
-                .show-key インターフェイス
-                .show-value= get_hdd(@parts_list.hdd_id).interface1
+                .show-key-box
+                  .show-key-content インターフェイス
+                .show-value-box
+                  .show-value-content= get_hdd(@parts_list.hdd_id).interface1
               .show-list__head
-                .show-key インターフェイス
-                .show-value= get_hdd(@parts_list.hdd_id).interface2
+                .show-key-box
+                  .show-key-content インターフェイス
+                .show-value-box
+                  .show-value-content= get_hdd(@parts_list.hdd_id).interface2
               .show-list__head
-                .show-key キャッシュ
-                .show-value= get_hdd(@parts_list.hdd_id).cache
+                .show-key-box
+                  .show-key-content キャッシュ
+                .show-value-box
+                  .show-value-content= get_hdd(@parts_list.hdd_id).cache
 
           - if get_ssd(@parts_list.ssd_id)
             .show-list
@@ -129,21 +167,30 @@
                 .show-image-name-box
                   .show-image-name-content= get_ssd(@parts_list.ssd_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_ssd(@parts_list.ssd_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_ssd(@parts_list.ssd_id).brand
               .show-list__head
-                .show-key 容量
-                .show-value= get_ssd(@parts_list.ssd_id).capacity
+                .show-key-box
+                  .show-key-content 容量
+                .show-value-box
+                  .show-value-content= get_ssd(@parts_list.ssd_id).capacity
               .show-list__head
-                .show-key 規格サイズ
-                .show-value= get_ssd(@parts_list.ssd_id).size
+                .show-key-box
+                  .show-key-content 規格サイズ
+                .show-value-box
+                  .show-value-content= get_ssd(@parts_list.ssd_id).size
               .show-list__head
-                .show-key インターフェイス
-                .show-value= get_ssd(@parts_list.ssd_id).interface
+                .show-key-box
+                  .show-key-content インターフェイス
+                .show-value-box
+                  .show-value-content= get_ssd(@parts_list.ssd_id).interface
               .show-list__head
-                .show-key タイプ
-                .show-value= get_ssd(@parts_list.ssd_id).ssdtype
-
+                .show-key-box
+                  .show-key-content タイプ
+                .show-value-box
+                  .show-value-content= get_ssd(@parts_list.ssd_id).ssdtype
 
           - if get_videocard(@parts_list.videocard_id)
             .show-list
@@ -154,23 +201,35 @@
                 .show-image-name-box
                   .show-image-name-content= get_videocard(@parts_list.videocard_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_videocard(@parts_list.videocard_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_videocard(@parts_list.videocard_id).brand
               .show-list__head
-                .show-key 搭載チップ
-                .show-value= get_videocard(@parts_list.videocard_id).chip
+                .show-key-box
+                  .show-key-content 搭載チップ
+                .show-value-box
+                  .show-value-content= get_videocard(@parts_list.videocard_id).chip
               .show-list__head
-                .show-key CUDAコア数
-                .show-value= get_videocard(@parts_list.videocard_id).core
+                .show-key-box
+                  .show-key-content CUDAコア数
+                .show-value-box
+                  .show-value-content= get_videocard(@parts_list.videocard_id).core
               .show-list__head
-                .show-key メモリ
-                .show-value= get_videocard(@parts_list.videocard_id).memory
+                .show-key-box
+                  .show-key-content メモリ
+                .show-value-box
+                  .show-value-content= get_videocard(@parts_list.videocard_id).memory
               .show-list__head
-                .show-key メモリクロック
-                .show-value= get_videocard(@parts_list.videocard_id).clock
+                .show-key-box
+                  .show-key-content メモリクロック
+                .show-value-box
+                  .show-value-content= get_videocard(@parts_list.videocard_id).clock
               .show-list__head
-                .show-key バスインターフェイス
-                .show-value= get_videocard(@parts_list.videocard_id).interface
+                .show-key-box
+                  .show-key-content バスインターフェイス
+                .show-value-box
+                  .show-value-content= get_videocard(@parts_list.videocard_id).interface
 
           - if get_powersupply(@parts_list.power_id)
             .show-list
@@ -181,17 +240,25 @@
                 .show-image-name-box
                   .show-image-name-content= get_powersupply(@parts_list.power_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_powersupply(@parts_list.power_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_powersupply(@parts_list.power_id).brand
               .show-list__head
-                .show-key 対応規格
-                .show-value= get_powersupply(@parts_list.power_id).standard
+                .show-key-box
+                  .show-key-content 対応規格
+                .show-value-box
+                  .show-value-content= get_powersupply(@parts_list.power_id).standard
               .show-list__head
-                .show-key 電源容量
-                .show-value= get_powersupply(@parts_list.power_id).capacity
+                .show-key-box
+                  .show-key-content 電源容量
+                .show-value-box
+                  .show-value-content= get_powersupply(@parts_list.power_id).capacity
               .show-list__head
-                .show-key 80PLUS認証
-                .show-value= get_powersupply(@parts_list.power_id).plus
+                .show-key-box
+                  .show-key-content 80PLUS認証
+                .show-value-box
+                  .show-value-content= get_powersupply(@parts_list.power_id).plus
 
           - if get_pccase(@parts_list.pccase_id)
             .show-list
@@ -202,17 +269,25 @@
                 .show-image-name-box
                   .show-image-name-content= get_pccase(@parts_list.pccase_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_pccase(@parts_list.pccase_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_pccase(@parts_list.pccase_id).brand
               .show-list__head
-                .show-key 対応ファクター
-                .show-value= get_pccase(@parts_list.pccase_id).factor
+                .show-key-box
+                  .show-key-content 対応ファクター
+                .show-value-box
+                  .show-value-content= get_pccase(@parts_list.pccase_id).factor
               .show-list__head
-                .show-key 重量
-                .show-value= get_pccase(@parts_list.pccase_id).weight
+                .show-key-box
+                  .show-key-content 重量
+                .show-value-box
+                  .show-value-content= get_pccase(@parts_list.pccase_id).weight
               .show-list__head
-                .show-key 幅x高さx奥行
-                .show-value= get_pccase(@parts_list.pccase_id).size_wdh
+                .show-key-box
+                  .show-key-content 幅x高さx奥行
+                .show-value-box
+                  .show-value-content= get_pccase(@parts_list.pccase_id).size_wdh
 
           - if get_cpucooler(@parts_list.cpucooler_id)
             .show-list
@@ -223,20 +298,30 @@
                 .show-image-name-box
                   .show-image-name-content= get_cpucooler(@parts_list.cpucooler_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_cpucooler(@parts_list.cpucooler_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).brand
               .show-list__head
-                .show-key Intel対応ソケット
-                .show-value= get_cpucooler(@parts_list.cpucooler_id).intel
+                .show-key-box
+                  .show-key-content Intel対応ソケット
+                .show-value-box
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).intel
               .show-list__head
-                .show-key AMD対応ソケット
-                .show-value= get_cpucooler(@parts_list.cpucooler_id).amd
+                .show-key-box
+                  .show-key-content AMD対応ソケット
+                .show-value-box
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).amd
               .show-list__head
-                .show-key タイプ
-                .show-value= get_cpucooler(@parts_list.cpucooler_id).flowtype
+                .show-key-box
+                  .show-key-content タイプ
+                .show-value-box
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).flowtype
               .show-list__head
-                .show-key ノイズレベル
-                .show-value= get_cpucooler(@parts_list.cpucooler_id).noise
+                .show-key-box
+                  .show-key-content ノイズレベル
+                .show-value-box
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).noise
 
           - if get_display(@parts_list.display_id)
             .show-list
@@ -247,18 +332,28 @@
                 .show-image-name-box
                   .show-image-name-content= get_display(@parts_list.display_id).name
               .show-list__head
-                .show-key メーカー
-                .show-value= get_display(@parts_list.display_id).brand
+                .show-key-box
+                  .show-key-content メーカー
+                .show-value-box
+                  .show-value-content= get_display(@parts_list.display_id).brand
               .show-list__head
-                .show-key モニタサイズ
-                .show-value= get_display(@parts_list.display_id).size
+                .show-key-box
+                  .show-key-content モニタサイズ
+                .show-value-box
+                  .show-value-content= get_display(@parts_list.display_id).size
               .show-list__head
-                .show-key モニタタイプ
-                .show-value= get_display(@parts_list.display_id).monitortype
+                .show-key-box
+                  .show-key-content モニタタイプ
+                .show-value-box
+                  .show-value-content= get_display(@parts_list.display_id).monitortype
               .show-list__head
-                .show-key 表示領域
-                .show-value= get_display(@parts_list.display_id).area
+                .show-key-box
+                  .show-key-content 表示領域
+                .show-value-box
+                  .show-value-content= get_display(@parts_list.display_id).area
               .show-list__head
-                .show-key コントラスト比
-                .show-value= get_display(@parts_list.display_id).contrast
+                .show-key-box
+                  .show-key-content コントラスト比
+                .show-value-box
+                  .show-value-content= get_display(@parts_list.display_id).contrast
           .show-space


### PR DESCRIPTION
# What
スクロールバーをx方向だけ表示させる
- div要素を追加してpaddingとoverflowを分ける
# Why
縦方向のスクロールバーがリストのすべての要素にでてしまうため修正する