### PR TITLE
パーツリスト 比較数を2リストに変更

### DIFF
--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -1,8 +1,8 @@
 $(function(){
 
-  function buildPartsListShowHead(partsList){
+  function buildPartsListShowHead(partsList, count){
     var html = `
-      <div class="show">
+      <div class="show" data-list-up-id=${count}>
         <div class="partslists__show">
           <div class="partslists__show__box">
             <div class="partslists__content__title__list-name">
@@ -1139,6 +1139,7 @@ $(function(){
 
 
   var listval = ""
+  var count = 0
 
   $('select').on('change select', function(){
     listval = $(this).val();
@@ -1147,13 +1148,19 @@ $(function(){
 
   $('#line-up-button').on('click', function(e){
     e.preventDefault();
-    // var formData = new FormData($('#line-up-select').get(0));
-    // var select_id = formData
-
     var path = location.pathname.match(new RegExp(/\/users\/\d+\/parts_lists\//))
     var url = `${path + listval}`
-    // var url = location.pathname
-    // console.log(url)
+    var listUpId1 = $('.show').attr("data-list-up-id");
+    var listUpId2 = $('.show:last').attr("data-list-up-id");
+    var listUpId = $($('.shows').children()).attr("data-list-up-id");
+    count += 1
+    console.log(listUpId1);
+    console.log(listUpId2);
+    console.log(count);
+    if (listUpId1 != listUpId2){
+      console.log("OK")
+      $('.show:first').remove()
+    }
     $.ajax({
       url: url,
       type: 'get',
@@ -1161,7 +1168,7 @@ $(function(){
       data: {id: listval}
     })
     .done(function(partsList){
-      let html = buildPartsListShowHead(partsList);
+      let html = buildPartsListShowHead(partsList, count);
       html += partsList.cpu ? BuildPartsListCpu(partsList) : HiddenCpu();
       html += partsList.mb ? buildPartsListMb(partsList) : HiddenMb();
       html += partsList.memory ? buildPartsListMemory(partsList) : HiddenMemory();

--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -1143,21 +1143,19 @@ $(function(){
 
   $('select').on('change select', function(){
     listval = $(this).val();
-    // console.log(listval);
   }).change();
 
   $('#line-up-button').on('click', function(e){
     e.preventDefault();
     var path = location.pathname.match(new RegExp(/\/users\/\d+\/parts_lists\//))
     var url = `${path + listval}`
+
+    // リスト追加時に既存のリストを消すためのdata取得
     var listUpId1 = $('.show').attr("data-list-up-id");
     var listUpId2 = $('.show:last').attr("data-list-up-id");
     count += 1
     var chooseId = $('#choose_list').prop("checked")
-    console.log(chooseId)
-    if (listUpId1 != listUpId2){
-      chooseId ? $('.show:first').remove() : $('.show:last').remove()
-    }
+    // ----------------------------------------
     $.ajax({
       url: url,
       type: 'get',
@@ -1177,11 +1175,18 @@ $(function(){
       html += partsList.cpucooler ? buildPartsListCpucooler(partsList) : HiddenCpucooler();
       html += partsList.display ? buildPartsListDisplay(partsList) : HiddenDisplay();
       html += buildPartsListShowFoot();
-      $('.shows').append(html);
 
+      // リスト削除
+      if (listUpId1 != listUpId2){
+        chooseId ? $('.show:last').remove() : $('.show:first').remove()
+      }
+      // リスト追加
+      chooseId ? $('.shows').append(html) : $('.shows').prepend(html);
+      // 幅50%
       $('.show').css({
         'width': '50%'
       });
+
     })
     .fail(function(){
       console.log("NG");

--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -1152,14 +1152,11 @@ $(function(){
     var url = `${path + listval}`
     var listUpId1 = $('.show').attr("data-list-up-id");
     var listUpId2 = $('.show:last').attr("data-list-up-id");
-    var listUpId = $($('.shows').children()).attr("data-list-up-id");
     count += 1
-    console.log(listUpId1);
-    console.log(listUpId2);
-    console.log(count);
+    var chooseId = $('#choose_list').prop("checked")
+    console.log(chooseId)
     if (listUpId1 != listUpId2){
-      console.log("OK")
-      $('.show:first').remove()
+      chooseId ? $('.show:first').remove() : $('.show:last').remove()
     }
     $.ajax({
       url: url,

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -311,6 +311,7 @@
         width: 100%;
         height: 50px;
         padding: 10px 0;
+        display: flex;
         &__box{
           display: flex;
           .list-title{

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -335,7 +335,77 @@
           box-shadow: inset 0 2px 0 rgba(255,255,255,0.4), inset 0 -2px 0 rgba(0, 0, 0, 0.15);
           cursor: pointer;
         }
+        &__btn{
+          padding-left: 70px;
+          &__name{
+            text-align: center;
+            margin-bottom: 2px;
+          }
+          /* === ボタンを表示するエリア ============================== */
+          #switchArea {
+            line-height    : 32px;                /* 1行の高さ          */
+            letter-spacing : 0;                   /* 文字間             */
+            text-align     : center;              /* 文字位置は中央     */
+            font-size      : 13px;                /* 文字サイズ         */
+            border-radius  : 12px;
+
+            position       : relative;            /* 親要素が基点       */
+            margin         : auto;                /* 中央寄せ           */
+            width          : 160px;               /* ボタンの横幅       */
+            background     : #fff;                /* デフォルト背景色   */
+          }
+          /* === チェックボックス ==================================== */
+          #switchArea input[type="checkbox"] {
+            display        : none;            /* チェックボックス非表示 */
+          }
+          /* === チェックボックスのラベル（標準） ==================== */
+          #switchArea label {
+            display        : block;               /* ボックス要素に変更 */
+            box-sizing     : border-box;          /* 枠線を含んだサイズ */
+            height         : 32px;                /* ボタンの高さ       */
+            border         : 2px solid rgba(142, 191, 255, 1);   /* 未選択タブのの枠線 */
+            border-radius  : 16px;                /* 角丸               */
+          }
+          /* === チェックボックスのラベル（ONのとき） ================ */
+          #switchArea input[type="checkbox"]:checked +label {
+            border-color   : rgba(58, 255, 58, 1);             /* 選択タブの枠線     */
+          }
+
+          /* === 表示する文字（標準） ================================ */
+          #switchArea label span:after{
+            content        : "左のリスト";               /* 表示する文字       */
+            padding        : 0 0 0 10px;          /* 表示する位置       */
+            color          : rgb(56, 135, 238);             /* 文字色             */
+          }
+
+          /* === 表示する文字（ONのとき） ============================ */
+          #switchArea  input[type="checkbox"]:checked + label span:after{
+            content        : "右のリスト";                /* 表示する文字       */
+            padding        : 0 0 0 10px;          /* 表示する位置       */
+            color          : rgb(47, 192, 47);             /* 文字色             */
+          }
+
+          /* === 丸部分のSTYLE（標準） =============================== */
+          #switchArea #swImg {
+            position       : absolute;            /* 親要素からの相対位置*/
+            width          : 24px;                /* 丸の横幅           */
+            height         : 24px;                /* 丸の高さ           */
+            background     : rgba(142, 191, 255, 1);             /* カーソルタブの背景 */
+            top            : 4px;                 /* 親要素からの位置   */
+            left           : 4px;                 /* 親要素からの位置   */
+            border-radius  : 12px;                /* 角丸               */
+            transition     : .2s;                 /* 滑らか変化         */
+          }
+
+          /* === 丸部分のSTYLE（ONのとき） =========================== */
+          #switchArea input[type="checkbox"]:checked ~ #swImg {
+            transform      : translateX(128px);    /* 丸も右へ移動       */
+            background     : rgba(58, 255, 58, 1);             /* カーソルタブの背景 */
+          }
+        }
       }
+
+
       .shows{
         width: 100%;
         display: flex;

--- a/app/views/parts_lists/show.html.haml
+++ b/app/views/parts_lists/show.html.haml
@@ -17,11 +17,12 @@
               = f.select :list_id, @lists.map { |parts_list| [parts_list.name, parts_list.id] }, selected: params[:list_id], id: "line-up-select"
               = f.submit id: "line-up-button",class: "show-line-up__add-btn", value: "パーツリストを追加", "data-disable-with":"パーツリストを追加"
         .show-line-up__btn
+          %p.show-line-up__btn__name 入れ替えるリスト
           #switchArea
-            %input#choose_list{:name => "choose_list", :type => "checkbox"}/
+            %input#choose_list{name: "choose_list", type: "checkbox", checked: "checked"}
             %label{:for => "choose_list"}
-              入れ替えるラベル
               %span
+            #swImg
       .shows
         .show{ data: {list_up_id: 0}}
           .partslists__show

--- a/app/views/parts_lists/show.html.haml
+++ b/app/views/parts_lists/show.html.haml
@@ -19,7 +19,7 @@
         .show-line-up__btn
 
       .shows
-        .show
+        .show{ data: {list_up_id: 0}}
           .partslists__show
             .partslists__show__box
               .partslists__content__title__list-name

--- a/app/views/parts_lists/show.html.haml
+++ b/app/views/parts_lists/show.html.haml
@@ -17,7 +17,11 @@
               = f.select :list_id, @lists.map { |parts_list| [parts_list.name, parts_list.id] }, selected: params[:list_id], id: "line-up-select"
               = f.submit id: "line-up-button",class: "show-line-up__add-btn", value: "パーツリストを追加", "data-disable-with":"パーツリストを追加"
         .show-line-up__btn
-
+          #switchArea
+            %input#choose_list{:name => "choose_list", :type => "checkbox"}/
+            %label{:for => "choose_list"}
+              入れ替えるラベル
+              %span
       .shows
         .show{ data: {list_up_id: 0}}
           .partslists__show


### PR DESCRIPTION
# What
リストを比較するとき3リスト以上に増えないようにする
- 3リスト目を選択した場合、既存のリストを削除する
- 削除する方のリストをチェックボックスで選択できるようにする
# Why
パーツリスト比較時、比較用リストがボタンを押した数だけ増えてしまうので
2リストまで表示されるように変更する
