### PR TITLE
画像リンクが無い場合のリンクの指定方法修正

### DIFF
--- a/app/assets/javascripts/flash.js
+++ b/app/assets/javascripts/flash.js
@@ -1,0 +1,6 @@
+// $(document).ready(function(){
+//   $('.notifications').
+// })
+$(function(){
+  setTimeout("$('.notifications').slideUp('slow')", 2000)
+})

--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -1155,11 +1155,22 @@ $(function(){
     listval = $(this).val();
   }).change();
 
+  // ページ読み込み時、リストが1つの時、何もないテーブルを隠す
+  $(document).ready(function(){
+    $('.show-image-name-content').each(function(index, element){
+      var divdiv = $(this).parents('.show-list')
+      if ($(element).text() == ""){
+        $(divdiv).css({
+          'display': 'none'
+        })
+      };
+    })
+  });
+
   $('#line-up-button').on('click', function(e){
     e.preventDefault();
     var path = location.pathname.match(new RegExp(/\/users\/\d+\/parts_lists\//))
     var url = `${path + listval}`
-
 
     // リスト追加時に既存のリストを消すためのdata取得
     var listUpId1 = $('.show').attr("data-list-up-id");
@@ -1167,6 +1178,10 @@ $(function(){
     count += 1
     var chooseId = $('#choose_list').prop("checked")
     // ----------------------------------------
+
+    // 
+
+
     $.ajax({
       url: url,
       type: 'get',

--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -19,13 +19,14 @@ $(function(){
   }
 
   function BuildPartsListCpu(partsList){
+    const imageUrl = partsList.cpu.image == "no_image.jpg" ? image_path(partsList.cpu.image) : partsList.cpu.image
     var html = `
     <div class="show-list">
       <div class="show-list__head">
         <div class="show-title">CPU</div>
       </div>
       <div class="show-list__head">
-        <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.cpu.image)}" width="120" height="120"></div>
+        <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
         <div class="show-image-name-box">
           <div class="show-image-name-content">${partsList.cpu.name}</div>
         </div>
@@ -101,13 +102,14 @@ $(function(){
   }
 
   function buildPartsListMb(partsList){
+    const imageUrl = partsList.mb.image == "no_image.jpg" ? image_path(partsList.mb.image) : partsList.mb.image
     var html = `
       <div class="show-list">
         <div class="show-list__head">
         <div class="show-title">マザーボード</div>
         </div>
         <div class="show-list__head">
-          <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.mb.image)}" width="120" height="120"></div>
+          <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
           <div class="show-image-name-box">
             <div class="show-image-name-content">${partsList.mb.name}</div>
           </div>
@@ -199,13 +201,14 @@ $(function(){
   }
 
   function buildPartsListMemory(partsList){
+    const imageUrl = partsList.memory.image == "no_image.jpg" ? image_path(partsList.memory.image) : partsList.memory.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">メモリー</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.memory.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
       <div class="show-image-name-box">
         <div class="show-image-name-content">${partsList.memory.name}</div>
       </div>
@@ -313,13 +316,14 @@ $(function(){
   }
 
   function buildPartsListHdd(partsList){
+    const imageUrl = partsList.hdd.image == "no_image.jpg" ? image_path(partsList.hdd.image) : partsList.hdd.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">HDD</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.hdd.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
       <div class="show-image-name-box">
       <div class="show-image-name-content">${partsList.hdd.name}</div>
       </div>
@@ -459,13 +463,14 @@ $(function(){
   }
 
   function buildPartsListSsd(partsList){
+    const imageUrl = partsList.ssd.image == "no_image.jpg" ? image_path(partsList.ssd.image) : partsList.ssd.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">SSD</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.ssd.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
         <div class="show-image-name-box">
           <div class="show-image-name-content">${partsList.ssd.name}</div>
         </div>
@@ -573,13 +578,14 @@ $(function(){
   }
 
   function buildPartsListVideocard(partsList){
+    const imageUrl = partsList.videocard.image == "no_image.jpg" ? image_path(partsList.videocard.image) : partsList.videocard.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">グラフィックボード</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.videocard.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
         <div class="show-image-name-box">
           <div class="show-image-name-content">${partsList.videocard.name}</div>
         </div>
@@ -703,13 +709,14 @@ $(function(){
   }
 
   function buildPartsListPower(partsList){
+    const imageUrl = partsList.power.image == "no_image.jpg" ? image_path(partsList.power.image) : partsList.power.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">電源ユニット</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.power.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
         <div class="show-image-name-box">
           <div class="show-image-name-content">${partsList.power.name}</div>
         </div>
@@ -801,13 +808,14 @@ $(function(){
   }
 
   function buildPartsListPccase(partsList){
+    const imageUrl = partsList.pccase.image == "no_image.jpg" ? image_path(partsList.pccase.image) : partsList.pccase.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">PCケース</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.pccase.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
         <div class="show-image-name-box">
           <div class="show-image-name-content">${partsList.pccase.name}</div>
         </div>
@@ -899,13 +907,14 @@ $(function(){
   }
 
   function buildPartsListCpucooler(partsList){
+    const imageUrl = partsList.cpucooler.image == "no_image.jpg" ? image_path(partsList.cpucooler.image) : partsList.cpucooler.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">CPUクーラー</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.cpucooler.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
         <div class="show-image-name-box">
           <div class="show-image-name-content">${partsList.cpucooler.name}</div>
         </div>
@@ -1013,13 +1022,14 @@ $(function(){
   }
 
   function buildPartsListDisplay(partsList){
+    const imageUrl = partsList.display.image == "no_image.jpg" ? image_path(partsList.display.image) : partsList.display.image
     var html = `
       <div class="show-list">
       <div class="show-list__head">
       <div class="show-title">液晶ディスプレイ</div>
       </div>
       <div class="show-list__head">
-      <div class="show-image"><img alt="No Image" class="td-image" src="${image_path(partsList.display.image)}" width="120" height="120"></div>
+      <div class="show-image"><img alt="No Image" class="td-image" src="${imageUrl}" width="120" height="120"></div>
         <div class="show-image-name-box">
           <div class="show-image-name-content">${partsList.display.name}</div>
         </div>

--- a/app/assets/javascripts/list-line_up.js
+++ b/app/assets/javascripts/list-line_up.js
@@ -1151,11 +1151,12 @@ $(function(){
   var listval = ""
   var count = 0
 
+  // パーツリスト切替セレクトボックスの初期値を取得
   $('select').on('change select', function(){
     listval = $(this).val();
   }).change();
 
-  // ページ読み込み時、リストが1つの時、何もないテーブルを隠す
+  // ページ読み込み時(リストが1つの時)、空のテーブルを隠す
   $(document).ready(function(){
     $('.show-image-name-content').each(function(index, element){
       var divdiv = $(this).parents('.show-list')
@@ -1167,6 +1168,7 @@ $(function(){
     })
   });
 
+  // 「パーツリストを追加」ボタンを押したら発火してリストを並べる
   $('#line-up-button').on('click', function(e){
     e.preventDefault();
     var path = location.pathname.match(new RegExp(/\/users\/\d+\/parts_lists\//))
@@ -1178,9 +1180,6 @@ $(function(){
     count += 1
     var chooseId = $('#choose_list').prop("checked")
     // ----------------------------------------
-
-    // 
-
 
     $.ajax({
       url: url,
@@ -1201,6 +1200,19 @@ $(function(){
       html += partsList.cpucooler ? buildPartsListCpucooler(partsList) : HiddenCpucooler();
       html += partsList.display ? buildPartsListDisplay(partsList) : HiddenDisplay();
       html += buildPartsListShowFoot();
+
+      // 隠しているリストのCSSを変更
+      if (listUpId1 == listUpId2){
+        $('.show-image-name-content').each(function(index, element){
+          var divdiv = $(this).parents('.show-list')
+          if ($(element).text() == ""){
+            $(divdiv).css({
+              'display': '',
+              'visibility': 'hidden'
+            })
+          };
+        })
+      }
 
       // リスト削除
       if (listUpId1 != listUpId2){

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -44,6 +44,8 @@
   .notifications {
     color: white;
     text-align: center;
+    z-index: 10;
+    float: center;
     .notice {
       height: 60px;
       line-height: 60px;

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -499,9 +499,6 @@
             }
           }
         }
-        #cpu-list{
-          // display:none
-        }
       }
       .hidden{
         visibility: hidden;

--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -499,6 +499,9 @@
             }
           }
         }
+        #cpu-list{
+          // display:none
+        }
       }
       .hidden{
         visibility: hidden;

--- a/app/controllers/parts_lists_controller.rb
+++ b/app/controllers/parts_lists_controller.rb
@@ -58,6 +58,7 @@ class PartsListsController < ApplicationController
 
   private
     def parts_list_params
+      params[:public_private] = PartsList.find(params[:id]).public_private unless params[:public_private]
       params.permit(:name, :cpu_id, :mb_id, :memory_id, :hdd_id, :ssd_id, :videocard_id, :power_id, :pccase_id, :cpucooler_id, :display_id).merge(public_private: params[:public_private]).merge(user_id: current_user.id)
     end
 

--- a/app/views/parts_lists/new.html.haml
+++ b/app/views/parts_lists/new.html.haml
@@ -8,6 +8,8 @@
       .devise-form
         = form_with url: user_parts_lists_path do |f|
           = f.text_field :name, autofocus: true, autocomplete: "name", class: "devise-form__box__text"
+          %label{for: "public_private"} リストを公開する
+          = f.check_box :public_private, class: "devise-form__box__checkbox", id: "public_private", checked: "0"
           = f.submit "新規作成", class: "devise-btn"
       .devise-link
         = link_to root_path do

--- a/app/views/parts_lists/show.html.haml
+++ b/app/views/parts_lists/show.html.haml
@@ -33,7 +33,7 @@
                 = link_to "リストを編集", edit_user_parts_list_path(current_user.id, @parts_list.id), class: "partslists__content__title__box__edit"
                 = link_to "リストを削除", user_parts_list_path(current_user.id, @parts_list.id), method: :delete, class: "partslists__content__title__box__delete"
           - if get_cpu(@parts_list.cpu_id) || true
-            .show-list#cpu-list
+            .show-list
               .show-list__head
                 .show-title= "CPU"
               .show-list__head

--- a/app/views/parts_lists/show.html.haml
+++ b/app/views/parts_lists/show.html.haml
@@ -32,333 +32,333 @@
               .partslists__content__title__box
                 = link_to "リストを編集", edit_user_parts_list_path(current_user.id, @parts_list.id), class: "partslists__content__title__box__edit"
                 = link_to "リストを削除", user_parts_list_path(current_user.id, @parts_list.id), method: :delete, class: "partslists__content__title__box__delete"
-          - if get_cpu(@parts_list.cpu_id)
-            .show-list
+          - if get_cpu(@parts_list.cpu_id) || true
+            .show-list#cpu-list
               .show-list__head
                 .show-title= "CPU"
               .show-list__head
-                .show-image= image_tag "#{get_cpu(@parts_list.cpu_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_cpu(@parts_list.cpu_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_cpu(@parts_list.cpu_id).name
+                  .show-image-name-content= get_cpu(@parts_list.cpu_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_cpu(@parts_list.cpu_id).brand
+                  .show-value-content= get_cpu(@parts_list.cpu_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content プロセッサー
                 .show-value-box
-                  .show-value-content= get_cpu(@parts_list.cpu_id).processor
+                  .show-value-content= get_cpu(@parts_list.cpu_id).try(:processor)
               .show-list__head
                 .show-key-box
                   .show-key-content ソケット形状
                 .show-value-box
-                  .show-value-content= get_cpu(@parts_list.cpu_id).socket
+                  .show-value-content= get_cpu(@parts_list.cpu_id).try(:socket)
 
-          - if get_motherboard(@parts_list.mb_id)
-            .show-list
+          - if get_motherboard(@parts_list.mb_id) || true
+            .show-list#mb-list
               .show-list__head
                 .show-title= "マザーボード"
               .show-list__head
-                .show-image= image_tag "#{get_motherboard(@parts_list.mb_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_motherboard(@parts_list.mb_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_motherboard(@parts_list.mb_id).name
+                  .show-image-name-content= get_motherboard(@parts_list.mb_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_motherboard(@parts_list.mb_id).brand
+                  .show-value-content= get_motherboard(@parts_list.mb_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content チップセット
                 .show-value-box
-                  .show-value-content= get_motherboard(@parts_list.mb_id).chipset
+                  .show-value-content= get_motherboard(@parts_list.mb_id).try(:chipset)
               .show-list__head
                 .show-key-box
                   .show-key-content フォームファクタ
                 .show-value-box
-                  .show-value-content= get_motherboard(@parts_list.mb_id).formfactor
+                  .show-value-content= get_motherboard(@parts_list.mb_id).try(:formfactor)
               .show-list__head
                 .show-key-box
                   .show-key-content ソケット形状
                 .show-value-box
-                  .show-value-content= get_motherboard(@parts_list.mb_id).socket
+                  .show-value-content= get_motherboard(@parts_list.mb_id).try(:socket)
 
-          - if get_memory(@parts_list.memory_id)
+          - if get_memory(@parts_list.memory_id) || true
             .show-list
               .show-list__head
                 .show-title= "メモリー"
               .show-list__head
-                .show-image= image_tag "#{get_memory(@parts_list.memory_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_memory(@parts_list.memory_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_memory(@parts_list.memory_id).name
+                  .show-image-name-content= get_memory(@parts_list.memory_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_memory(@parts_list.memory_id).brand
+                  .show-value-content= get_memory(@parts_list.memory_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content メモリ容量(1枚あたり)
                 .show-value-box
-                  .show-value-content= get_memory(@parts_list.memory_id).capacity
+                  .show-value-content= get_memory(@parts_list.memory_id).try(:capacity)
               .show-list__head
                 .show-key-box
                   .show-key-content 枚数
                 .show-value-box
-                  .show-value-content= get_memory(@parts_list.memory_id).setnumber
+                  .show-value-content= get_memory(@parts_list.memory_id).try(:setnumber)
               .show-list__head
                 .show-key-box
                   .show-key-content メモリ規格
                 .show-value-box
-                  .show-value-content= get_memory(@parts_list.memory_id).standard
+                  .show-value-content= get_memory(@parts_list.memory_id).try(:standard)
               .show-list__head
                 .show-key-box
                   .show-key-content メモリインターフェイス
                 .show-value-box
-                  .show-value-content= get_memory(@parts_list.memory_id).interface
+                  .show-value-content= get_memory(@parts_list.memory_id).try(:interface)
 
-          - if get_hdd(@parts_list.hdd_id)
+          - if get_hdd(@parts_list.hdd_id) || true
             .show-list
               .show-list__head
                 .show-title= "HDD"
               .show-list__head
-                .show-image= image_tag "#{get_hdd(@parts_list.hdd_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_hdd(@parts_list.hdd_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_hdd(@parts_list.hdd_id).name
+                  .show-image-name-content= get_hdd(@parts_list.hdd_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_hdd(@parts_list.hdd_id).brand
+                  .show-value-content= get_hdd(@parts_list.hdd_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content シリーズ
                 .show-value-box
-                  .show-value-content= get_hdd(@parts_list.hdd_id).series
+                  .show-value-content= get_hdd(@parts_list.hdd_id).try(:series)
               .show-list__head
                 .show-key-box
                   .show-key-content 容量
                 .show-value-box
-                  .show-value-content= get_hdd(@parts_list.hdd_id).capacity
+                  .show-value-content= get_hdd(@parts_list.hdd_id).try(:capacity)
               .show-list__head
                 .show-key-box
                   .show-key-content 回転数
                 .show-value-box
-                  .show-value-content= get_hdd(@parts_list.hdd_id).speed
+                  .show-value-content= get_hdd(@parts_list.hdd_id).try(:speed)
               .show-list__head
                 .show-key-box
                   .show-key-content インターフェイス
                 .show-value-box
-                  .show-value-content= get_hdd(@parts_list.hdd_id).interface1
+                  .show-value-content= get_hdd(@parts_list.hdd_id).try(:interface1)
               .show-list__head
                 .show-key-box
                   .show-key-content インターフェイス
                 .show-value-box
-                  .show-value-content= get_hdd(@parts_list.hdd_id).interface2
+                  .show-value-content= get_hdd(@parts_list.hdd_id).try(:interface2)
               .show-list__head
                 .show-key-box
                   .show-key-content キャッシュ
                 .show-value-box
-                  .show-value-content= get_hdd(@parts_list.hdd_id).cache
+                  .show-value-content= get_hdd(@parts_list.hdd_id).try(:cache)
 
-          - if get_ssd(@parts_list.ssd_id)
+          - if get_ssd(@parts_list.ssd_id) || true
             .show-list
               .show-list__head
                 .show-title= "SSD"
               .show-list__head
-                .show-image= image_tag "#{get_ssd(@parts_list.ssd_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_ssd(@parts_list.ssd_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_ssd(@parts_list.ssd_id).name
+                  .show-image-name-content= get_ssd(@parts_list.ssd_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_ssd(@parts_list.ssd_id).brand
+                  .show-value-content= get_ssd(@parts_list.ssd_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content 容量
                 .show-value-box
-                  .show-value-content= get_ssd(@parts_list.ssd_id).capacity
+                  .show-value-content= get_ssd(@parts_list.ssd_id).try(:capacity)
               .show-list__head
                 .show-key-box
                   .show-key-content 規格サイズ
                 .show-value-box
-                  .show-value-content= get_ssd(@parts_list.ssd_id).size
+                  .show-value-content= get_ssd(@parts_list.ssd_id).try(:size)
               .show-list__head
                 .show-key-box
                   .show-key-content インターフェイス
                 .show-value-box
-                  .show-value-content= get_ssd(@parts_list.ssd_id).interface
+                  .show-value-content= get_ssd(@parts_list.ssd_id).try(:interface)
               .show-list__head
                 .show-key-box
                   .show-key-content タイプ
                 .show-value-box
-                  .show-value-content= get_ssd(@parts_list.ssd_id).ssdtype
+                  .show-value-content= get_ssd(@parts_list.ssd_id).try(:ssdtype)
 
-          - if get_videocard(@parts_list.videocard_id)
+          - if get_videocard(@parts_list.videocard_id) || true
             .show-list
               .show-list__head
                 .show-title= "グラフィックボード"
               .show-list__head
-                .show-image= image_tag "#{get_videocard(@parts_list.videocard_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_videocard(@parts_list.videocard_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_videocard(@parts_list.videocard_id).name
+                  .show-image-name-content= get_videocard(@parts_list.videocard_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_videocard(@parts_list.videocard_id).brand
+                  .show-value-content= get_videocard(@parts_list.videocard_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content 搭載チップ
                 .show-value-box
-                  .show-value-content= get_videocard(@parts_list.videocard_id).chip
+                  .show-value-content= get_videocard(@parts_list.videocard_id).try(:chip)
               .show-list__head
                 .show-key-box
                   .show-key-content CUDAコア数
                 .show-value-box
-                  .show-value-content= get_videocard(@parts_list.videocard_id).core
+                  .show-value-content= get_videocard(@parts_list.videocard_id).try(:core)
               .show-list__head
                 .show-key-box
                   .show-key-content メモリ
                 .show-value-box
-                  .show-value-content= get_videocard(@parts_list.videocard_id).memory
+                  .show-value-content= get_videocard(@parts_list.videocard_id).try(:memory)
               .show-list__head
                 .show-key-box
                   .show-key-content メモリクロック
                 .show-value-box
-                  .show-value-content= get_videocard(@parts_list.videocard_id).clock
+                  .show-value-content= get_videocard(@parts_list.videocard_id).try(:clock)
               .show-list__head
                 .show-key-box
                   .show-key-content バスインターフェイス
                 .show-value-box
-                  .show-value-content= get_videocard(@parts_list.videocard_id).interface
+                  .show-value-content= get_videocard(@parts_list.videocard_id).try(:interface)
 
-          - if get_powersupply(@parts_list.power_id)
+          - if get_powersupply(@parts_list.power_id) || true
             .show-list
               .show-list__head
                 .show-title= "電源ユニット"
               .show-list__head
-                .show-image= image_tag "#{get_powersupply(@parts_list.power_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_powersupply(@parts_list.power_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_powersupply(@parts_list.power_id).name
+                  .show-image-name-content= get_powersupply(@parts_list.power_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_powersupply(@parts_list.power_id).brand
+                  .show-value-content= get_powersupply(@parts_list.power_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content 対応規格
                 .show-value-box
-                  .show-value-content= get_powersupply(@parts_list.power_id).standard
+                  .show-value-content= get_powersupply(@parts_list.power_id).try(:standard)
               .show-list__head
                 .show-key-box
                   .show-key-content 電源容量
                 .show-value-box
-                  .show-value-content= get_powersupply(@parts_list.power_id).capacity
+                  .show-value-content= get_powersupply(@parts_list.power_id).try(:capacity)
               .show-list__head
                 .show-key-box
                   .show-key-content 80PLUS認証
                 .show-value-box
-                  .show-value-content= get_powersupply(@parts_list.power_id).plus
+                  .show-value-content= get_powersupply(@parts_list.power_id).try(:plus)
 
-          - if get_pccase(@parts_list.pccase_id)
+          - if get_pccase(@parts_list.pccase_id) || true
             .show-list
               .show-list__head
                 .show-title= "PCケース"
               .show-list__head
-                .show-image= image_tag "#{get_pccase(@parts_list.pccase_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_pccase(@parts_list.pccase_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_pccase(@parts_list.pccase_id).name
+                  .show-image-name-content= get_pccase(@parts_list.pccase_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_pccase(@parts_list.pccase_id).brand
+                  .show-value-content= get_pccase(@parts_list.pccase_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content 対応ファクター
                 .show-value-box
-                  .show-value-content= get_pccase(@parts_list.pccase_id).factor
+                  .show-value-content= get_pccase(@parts_list.pccase_id).try(:factor)
               .show-list__head
                 .show-key-box
                   .show-key-content 重量
                 .show-value-box
-                  .show-value-content= get_pccase(@parts_list.pccase_id).weight
+                  .show-value-content= get_pccase(@parts_list.pccase_id).try(:weight)
               .show-list__head
                 .show-key-box
                   .show-key-content 幅x高さx奥行
                 .show-value-box
-                  .show-value-content= get_pccase(@parts_list.pccase_id).size_wdh
+                  .show-value-content= get_pccase(@parts_list.pccase_id).try(:size_wdh)
 
-          - if get_cpucooler(@parts_list.cpucooler_id)
+          - if get_cpucooler(@parts_list.cpucooler_id) || true
             .show-list
               .show-list__head
                 .show-title= "CPUクーラー"
               .show-list__head
-                .show-image= image_tag "#{get_cpucooler(@parts_list.cpucooler_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_cpucooler(@parts_list.cpucooler_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_cpucooler(@parts_list.cpucooler_id).name
+                  .show-image-name-content= get_cpucooler(@parts_list.cpucooler_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).brand
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content Intel対応ソケット
                 .show-value-box
-                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).intel
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).try(:intel)
               .show-list__head
                 .show-key-box
                   .show-key-content AMD対応ソケット
                 .show-value-box
-                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).amd
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).try(:amd)
               .show-list__head
                 .show-key-box
                   .show-key-content タイプ
                 .show-value-box
-                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).flowtype
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).try(:flowtype)
               .show-list__head
                 .show-key-box
                   .show-key-content ノイズレベル
                 .show-value-box
-                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).noise
+                  .show-value-content= get_cpucooler(@parts_list.cpucooler_id).try(:noise)
 
-          - if get_display(@parts_list.display_id)
+          - if get_display(@parts_list.display_id) || true
             .show-list
               .show-list__head
                 .show-title= "液晶ディスプレイ"
               .show-list__head
-                .show-image= image_tag "#{get_display(@parts_list.display_id).image}", size: "120x120", alt: "No Image", class: "td-image"
+                .show-image= image_tag "#{get_display(@parts_list.display_id).try(:image)}", size: "120x120", alt: "No Image", class: "td-image"
                 .show-image-name-box
-                  .show-image-name-content= get_display(@parts_list.display_id).name
+                  .show-image-name-content= get_display(@parts_list.display_id).try(:name)
               .show-list__head
                 .show-key-box
                   .show-key-content メーカー
                 .show-value-box
-                  .show-value-content= get_display(@parts_list.display_id).brand
+                  .show-value-content= get_display(@parts_list.display_id).try(:brand)
               .show-list__head
                 .show-key-box
                   .show-key-content モニタサイズ
                 .show-value-box
-                  .show-value-content= get_display(@parts_list.display_id).size
+                  .show-value-content= get_display(@parts_list.display_id).try(:size)
               .show-list__head
                 .show-key-box
                   .show-key-content モニタタイプ
                 .show-value-box
-                  .show-value-content= get_display(@parts_list.display_id).monitortype
+                  .show-value-content= get_display(@parts_list.display_id).try(:monitortype)
               .show-list__head
                 .show-key-box
                   .show-key-content 表示領域
                 .show-value-box
-                  .show-value-content= get_display(@parts_list.display_id).area
+                  .show-value-content= get_display(@parts_list.display_id).try(:area)
               .show-list__head
                 .show-key-box
                   .show-key-content コントラスト比
                 .show-value-box
-                  .show-value-content= get_display(@parts_list.display_id).contrast
+                  .show-value-content= get_display(@parts_list.display_id).try(:contrast)
           .show-space


### PR DESCRIPTION
# What
- jQueryで追加する画像リンクをno_image.jpgに対応
- 非表示リストの非表示方法を変更
  - 変更前
    if文を用いて場合分け
  - 変更後
    HTMLの要素を残しつつCSSで非表示にする
    -> jQueryでCSSを書き換えて見え方を変える
- flashをjQueryでslide_upさせる
# Why
- jQueryで追加した画像の画像リンクが無い場合、リンクの指定方法に問題があり画像が表示されないため修正
- パーツリストを並べた際に高さが揃っていなかったため修正
- flashの表示時間を有限(2秒)に変更