### PR TITLE
【デプロイ】 DB参照をIDからカテゴリー名に変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,6 +94,46 @@ module ApplicationHelper
     Display.find_by_id(id)
   end
 
+# ==================================================================================
+  # 本番環境でリンクを飛ぶ際の各パーツのリンク先
+  def link_cpu
+    pcpart_path(Pcpart.find_by(category: "CPU").id)
+  end
 
+  def link_motherboard
+    pcpart_path(Pcpart.find_by(category: "マザーボード").id)
+  end
+
+  def link_memory
+    pcpart_path(Pcpart.find_by(category: "メモリー").id)
+  end
+
+  def link_hdd
+    pcpart_path(Pcpart.find_by(category: "HDD").id)
+  end
+
+  def link_ssd
+    pcpart_path(Pcpart.find_by(category: "SSD").id)
+  end
+
+  def link_videocard
+    pcpart_path(Pcpart.find_by(category: "グラフィックボード").id)
+  end
+
+  def link_powersupply
+    pcpart_path(Pcpart.find_by(category: "電源ユニット").id)
+  end
+
+  def link_pccase
+    pcpart_path(Pcpart.find_by(category: "PCケース").id)
+  end
+
+  def link_cpucooler
+    pcpart_path(Pcpart.find_by(category: "CPUクーラー").id)
+  end
+
+  def link_display
+    pcpart_path(Pcpart.find_by(category: "液晶ディスプレイ").id)
+  end
 
 end

--- a/app/views/pcparts/_side-bar.html.haml
+++ b/app/views/pcparts/_side-bar.html.haml
@@ -1,21 +1,21 @@
 .side-bar__list
-  = link_to pcpart_path(1), class: "side-bar__list__category" do
+  = link_to link_cpu, class: "side-bar__list__category" do
     CPU
-  = link_to pcpart_path(2), class: "side-bar__list__category" do
+  = link_to link_motherboard, class: "side-bar__list__category" do
     マザーボード
-  = link_to pcpart_path(3), class: "side-bar__list__category" do
+  = link_to link_memory, class: "side-bar__list__category" do
     メモリー
-  = link_to pcpart_path(4), class: "side-bar__list__category" do
+  = link_to link_hdd, class: "side-bar__list__category" do
     HDD
-  = link_to pcpart_path(5), class: "side-bar__list__category" do
+  = link_to link_ssd, class: "side-bar__list__category" do
     SSD
-  = link_to pcpart_path(6), class: "side-bar__list__category" do
+  = link_to link_videocard, class: "side-bar__list__category" do
     グラフィックボード
-  = link_to pcpart_path(7), class: "side-bar__list__category" do
+  = link_to link_powersupply, class: "side-bar__list__category" do
     電源ユニット
-  = link_to pcpart_path(8), class: "side-bar__list__category" do
+  = link_to link_pccase, class: "side-bar__list__category" do
     PCケース
-  = link_to pcpart_path(9), class: "side-bar__list__category" do
+  = link_to link_cpucooler, class: "side-bar__list__category" do
     CPUクーラー
-  = link_to pcpart_path(10), class: "side-bar__list__category" do
+  = link_to link_display, class: "side-bar__list__category" do
     液晶ディスプレイ

--- a/app/views/pcparts/_updatedb.html.haml
+++ b/app/views/pcparts/_updatedb.html.haml
@@ -1,21 +1,21 @@
-- case params[:id]
-- when "1"
+- case @category.category
+- when "CPU"
   = link_to "DB更新", "/pcparts/1/cpus", method: :post
-- when "2"
+- when "マザーボード"
   = link_to "DB更新", "/pcparts/2/mbs", method: :post
-- when "3"
+- when "メモリー"
   = link_to "DB更新", "/pcparts/3/memories", method: :post
-- when "4"
+- when "HDD"
   = link_to "DB更新", "/pcparts/4/hdds", method: :post
-- when "5"
+- when "SSD"
   = link_to "DB更新", "/pcparts/5/ssds", method: :post
-- when "6"
+- when "グラフィックボード"
   = link_to "DB更新", "/pcparts/6/videocards", method: :post
-- when "7"
+- when "電源ユニット"
   = link_to "DB更新", "/pcparts/7/powers", method: :post
-- when "8"
+- when "PCケース"
   = link_to "DB更新", "/pcparts/8/pccases", method: :post
-- when "9"
+- when "CPUクーラー"
   = link_to "DB更新", "/pcparts/9/cpucoolers", method: :post
-- when "10"
+- when "液晶ディスプレイ"
   = link_to "DB更新", "/pcparts/9/displays", method: :post

--- a/app/views/pcparts/show.html.haml
+++ b/app/views/pcparts/show.html.haml
@@ -23,24 +23,24 @@
               .select-list
                 = f.select :list_id, @parts_lists.map { |parts_list| [parts_list.name, parts_list.id] }, selected: params[:list_id]
         .contents-main
-          - case @category.id
-          - when 1
+          - case @category.category
+          - when "CPU"
             = render partial: "pcparts/category/cpu", collection: @cpus, locals: {:f => f}
-          - when 2
+          - when "マザーボード"
             = render partial: "pcparts/category/mb", collection: @mbs, locals: {:f => f}
-          - when 3
+          - when "メモリー"
             = render partial: "pcparts/category/memory", collection: @memories, locals: {:f => f}
-          - when 4
+          - when "HDD"
             = render partial: "pcparts/category/hdd", collection: @hdds, locals: {:f => f}
-          - when 5
+          - when "SSD"
             = render partial: "pcparts/category/ssd", collection: @ssds, locals: {:f => f}
-          - when 6
+          - when "グラフィックボード"
             = render partial: "pcparts/category/videocard", collection: @videocards, locals: {:f => f}
-          - when 7
+          - when "電源ユニット"
             = render partial: "pcparts/category/power", collection: @powers, locals: {:f => f}
-          - when 8
+          - when "PCケース"
             = render partial: "pcparts/category/pccase", collection: @pccases, locals: {:f => f}
-          - when 9
+          - when "CPUクーラー"
             = render partial: "pcparts/category/cpucooler", collection: @cpucoolers, locals: {:f => f}
-          - when 10
+          - when "液晶ディスプレイ"
             = render partial: "pcparts/category/display", collection: @displays, locals: {:f => f}


### PR DESCRIPTION
# What
カテゴリー参照時にIDを参照していたのをカテゴリー名を参照するように変更

# Why
HerokuのMySQLでIDが10ずつ増えるため、開発環境・本番環両方に対応するよう更新を行う
- 開発環境 ID:1=>カテゴリー:CPU, ID:2=>カテゴリー:マザーボード...
- 本番環境 ID:1=>カテゴリー:CPU, ID:**11**=>カテゴリー:マザーボード...