### PR TITLE
パーツリスト比較のボタン追加

### DIFF
--- a/app/assets/stylesheets/parts-list.scss
+++ b/app/assets/stylesheets/parts-list.scss
@@ -247,9 +247,46 @@
               font-size: 40px;
               font-weight: bold;
               padding-left: 5px;
+              position: relative;
+
               a {
                 text-decoration: none;
                 color: #000;
+              }
+
+              &__fukidashi {
+                opacity: 0;
+                width: 390px;
+                font-size: 16px;
+                line-height: 20px;
+                position: absolute;
+                top: -55px;
+                left: 0;
+                padding: 16px;
+                border-radius: 5px;
+                background: #33cc99;
+                color: #fff;
+                font-weight: bold;
+
+                &:after {
+                  position: absolute;
+                  width: 0;
+                  height: 0;
+                  left: 0;
+                  bottom: -19px;
+                  margin-left: 15px;
+                  border: solid transparent;
+                  border-color: rgba(51, 204, 153, 0);
+                  border-top-color: #33cc99;
+                  border-width: 10px;
+                  pointer-events: none;
+                  content: " ";
+                }
+              }
+
+              a:hover + p {
+                opacity: 1;
+                transition-duration:.3s;
               }
             }
 
@@ -258,6 +295,11 @@
               display: flex;
               justify-content: space-between;
               box-sizing: border-box;
+
+              &__compare {
+                @include button(#FFF, #fd9535, #d27d00);
+                margin-right: 20px;
+              }
 
               &__edit {
                 @include button(#1436f7, #b0cef5, #8ebfff);

--- a/app/views/parts_lists/index.html.haml
+++ b/app/views/parts_lists/index.html.haml
@@ -15,9 +15,10 @@
         .partslists__content
           .partslists__content__title
             .partslists__content__title__list-name
-              = link_to list.name, user_parts_list_path(current_user.id, list.id)
+              = link_to list.name, edit_user_parts_list_path(current_user.id, list.id), class: "partslists__content__title__list-name__name"
+              %p.partslists__content__title__list-name__fukidashi リスト名をクリックするとリストの編集に移動します
             .partslists__content__title__box
-              = link_to "リストを編集", edit_user_parts_list_path(current_user.id, list.id), class: "partslists__content__title__box__edit"
+              = link_to "リストを比較", user_parts_list_path(current_user.id, list.id), class: "partslists__content__title__box__compare"
               = link_to "リストを削除", user_parts_list_path(current_user.id, list.id), method: :delete, class: "partslists__content__title__box__delete"
 
           .shows


### PR DESCRIPTION
# What
- リストを比較するボタンを追加
- リストを編集はリスト名をクリックに変更
  - リスト名をhoverするとコメント表示される

# Why
パーツリスト比較ページに移動するリンクがわかりづらいので変更する